### PR TITLE
Oracle linux support

### DIFF
--- a/DRV/remake
+++ b/DRV/remake
@@ -2,6 +2,7 @@
 # Copyright (c) 2021 Open Compute Project
 # Copyright [2023] Hewlett Packard Enterprise Development LP
 #     Modified: added SLE support to the remake shell script with supporting docs
+#     Modified: added OL support to the remake shell script
 set -euo pipefail
 
 DIST="$(awk -F= '/^NAME/{print tolower($2)}' /etc/os-release|awk 'gsub(/[" ]/,x) + 1')"
@@ -18,6 +19,9 @@ case "$DIST" in
         KDIR=/usr/src/linux-${KVER}
         ;;
     centos*)
+        KDIR=/usr/src/kernels/${KVER}
+        ;;
+    oraclelinux*)
         KDIR=/usr/src/kernels/${KVER}
         ;;
     sle*)

--- a/DRV/remake
+++ b/DRV/remake
@@ -2,7 +2,6 @@
 # Copyright (c) 2021 Open Compute Project
 # Copyright [2023] Hewlett Packard Enterprise Development LP
 #     Modified: added SLE support to the remake shell script with supporting docs
-#     Modified: added OL support to the remake shell script
 set -euo pipefail
 
 DIST="$(awk -F= '/^NAME/{print tolower($2)}' /etc/os-release|awk 'gsub(/[" ]/,x) + 1')"


### PR DESCRIPTION
Adds simple support to the remake script for installing on Oracle Linux variants.